### PR TITLE
ffmpeg: libavcodec: Revert sdclang workaround

### DIFF
--- a/libavcodec/Android.mk
+++ b/libavcodec/Android.mk
@@ -45,8 +45,5 @@ ifneq ($(ARCH_ARM_HAVE_NEON),)
   LOCAL_SRC_FILES += neon/mpegvideo.c
 endif
 
-# This file crashes SDCLANG at -O2 or -O3
-$(intermediates)/vp9dsp_8bpp.o: PRIVATE_CFLAGS += $(if $(filter arm64,$(TARGET_ARCH)),-O1)
-
 LOCAL_MULTILIB := $(FFMPEG_MULTILIB)
 include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
As of sdclang 3.8.7, the original issue has been fixed.

This partially reverts commit 9e7e1db09b3956542e234812ff1377cf1bb3208b.

Change-Id: Iea563cd7e4d2a5db21e381209abf43f8d94c7cb2